### PR TITLE
fix: moves json logger and pyyaml dep out of dev

### DIFF
--- a/aind-session-json-service-server/pyproject.toml
+++ b/aind-session-json-service-server/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     'pydantic>=2.0',
     'pydantic-settings>=2.0',
     'fastapi[standard]>=0.114.0',
+    'python-json-logger',
+    'PyYAML'
 ]
 
 [project.optional-dependencies]
@@ -36,8 +38,6 @@ dev = [
     'pytest-env',
     'pytest-mock',
     'pytest_asyncio',
-    'python-json-logger',
-    'PyYAML'
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
The github action to build_client failed because the python-json-logger dependency was in [dev]